### PR TITLE
lock data-plane-api version to support envoy v1.11.0

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,6 +27,10 @@ ignored = [
   revision = "v0.5.0"
 
 [[constraint]]
+  name = "github.com/envoyproxy/data-plane-api"
+  revision = "1fc1f69dcaef7980421d362e11e895897450bcaf"
+
+[[constraint]]
   name = "github.com/gambol99/go-marathon"
   revision = "v0.7.1"
 


### PR DESCRIPTION
Locking the current latest version so that this does not break when data-plane-api is updated.