### PR TITLE
removing support for updating the health_status from the EDS

### DIFF
--- a/xds/adapter/eds.go
+++ b/xds/adapter/eds.go
@@ -83,13 +83,12 @@ func (e eds) tbnClusterToEnvoyLoadAssignment(
 
 func mkEnvoyLbEndpoint(host string, port int, metadata tbnapi.Metadata) *envoyendpoint.LbEndpoint {
 	return &envoyendpoint.LbEndpoint{
-                HostIdentifier: &envoyendpoint.LbEndpoint_Endpoint{
-		        Endpoint: &envoyendpoint.Endpoint{
-		                Address: mkEnvoyAddress(host, port),
-		        },
-                },
-		HealthStatus: envoycore.HealthStatus_HEALTHY,
-		Metadata:     toEnvoyMetadata(metadata),
+		HostIdentifier: &envoyendpoint.LbEndpoint_Endpoint{
+			Endpoint: &envoyendpoint.Endpoint{
+				Address: mkEnvoyAddress(host, port),
+			},
+		},
+		Metadata: toEnvoyMetadata(metadata),
 	}
 }
 

--- a/xds/adapter/eds_test.go
+++ b/xds/adapter/eds_test.go
@@ -97,7 +97,6 @@ func TestFullRequestFullClusterLoadAssignments(t *testing.T) {
 									},
 								},
 							},
-							HealthStatus: envoycore.HealthStatus_HEALTHY,
 							Metadata: &envoycore.Metadata{
 								FilterMetadata: map[string]*types.Struct{
 									"envoy.lb": {
@@ -124,7 +123,6 @@ func TestFullRequestFullClusterLoadAssignments(t *testing.T) {
 									},
 								},
 							},
-							HealthStatus: envoycore.HealthStatus_HEALTHY,
 							Metadata: &envoycore.Metadata{
 								FilterMetadata: map[string]*types.Struct{
 									"envoy.lb": {
@@ -151,7 +149,6 @@ func TestFullRequestFullClusterLoadAssignments(t *testing.T) {
 									},
 								},
 							},
-							HealthStatus: envoycore.HealthStatus_HEALTHY,
 							Metadata: &envoycore.Metadata{
 								FilterMetadata: map[string]*types.Struct{
 									"envoy.lb": {
@@ -178,7 +175,6 @@ func TestFullRequestFullClusterLoadAssignments(t *testing.T) {
 									},
 								},
 							},
-							HealthStatus: envoycore.HealthStatus_HEALTHY,
 							Metadata: &envoycore.Metadata{
 								FilterMetadata: map[string]*types.Struct{
 									"envoy.lb": {
@@ -214,8 +210,7 @@ func TestFullRequestFullClusterLoadAssignments(t *testing.T) {
 									},
 								},
 							},
-							HealthStatus: envoycore.HealthStatus_HEALTHY,
-							Metadata:     &envoycore.Metadata{},
+							Metadata: &envoycore.Metadata{},
 						},
 					},
 				},
@@ -240,7 +235,6 @@ func TestFullRequestFullClusterLoadAssignments(t *testing.T) {
 									},
 								},
 							},
-							HealthStatus: envoycore.HealthStatus_HEALTHY,
 							Metadata: &envoycore.Metadata{
 								FilterMetadata: map[string]*types.Struct{
 									"envoy.lb": {
@@ -265,7 +259,6 @@ func TestFullRequestFullClusterLoadAssignments(t *testing.T) {
 									},
 								},
 							},
-							HealthStatus: envoycore.HealthStatus_HEALTHY,
 							Metadata: &envoycore.Metadata{
 								FilterMetadata: map[string]*types.Struct{
 									"envoy.lb": {
@@ -292,7 +285,6 @@ func TestFullRequestFullClusterLoadAssignments(t *testing.T) {
 									},
 								},
 							},
-							HealthStatus: envoycore.HealthStatus_HEALTHY,
 							Metadata: &envoycore.Metadata{
 								FilterMetadata: map[string]*types.Struct{
 									"envoy.lb": {


### PR DESCRIPTION
EDS was sending heath_status  as health by default. This was causing issue when a instance comes up in the stack, EDS supposedly sets the health status of the host of LbEndpoint in a envoy cluster. This actually bypasses the HTTP/gRPC layer healthcheck as it assumes the health status is being passed by the EDS which it needs to set. 

In our current arch, EDS should not have this ability, envoy should just do the active health checking and mark it healthy once the upstream container sends back the health check flag as healthy